### PR TITLE
Add minimal Quarto analysis project

### DIFF
--- a/learning-methods/.gitignore
+++ b/learning-methods/.gitignore
@@ -1,0 +1,8 @@
+# Ignore dataset and caches
+/data/
+*.Rproj.user/
+*.html
+*.pdf
+*.docx
+*.log
+cache/

--- a/learning-methods/README.md
+++ b/learning-methods/README.md
@@ -1,0 +1,20 @@
+# Learning Methods: LSA and LDA
+
+## Project Goal
+Analyze the **Student Performance & Learning Style** dataset to explore which learning method works best using text analytics (LSA, LDA, sentiment).
+
+## Setup
+1. Place `student-math-learning.csv` from Kaggle in `data/`.
+2. In R run `source("install.R")` to install required packages.
+
+## Run Slides
+Execute in shell:
+
+```bash
+quarto render quarto/learning_lsa_lda.qmd --to revealjs
+```
+
+Open the generated HTML in your browser to view the slides.
+
+## Results Preview
+Slides include exploratory visualizations of LSA topics, LDA top terms, and sentiment analysis summarizing findings.

--- a/learning-methods/install.R
+++ b/learning-methods/install.R
@@ -1,0 +1,17 @@
+packages <- c(
+  "tidyverse",
+  "tidytext",
+  "lsa",
+  "topicmodels",
+  "umap",
+  "ggwordcloud",
+  "textmineR"
+)
+
+install_if_missing <- function(pkg) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    install.packages(pkg, repos = "https://cloud.r-project.org")
+  }
+}
+
+invisible(lapply(packages, install_if_missing))

--- a/learning-methods/quarto/learning_lsa_lda.qmd
+++ b/learning-methods/quarto/learning_lsa_lda.qmd
@@ -1,0 +1,96 @@
+---
+title: "Learning Methods Analysis"
+format: revealjs
+---
+
+# Title
+
+## Which study method works best?
+
+---
+
+# Agenda
+
+1. Data load
+2. Cleaning
+3. LSA
+4. LDA
+5. Sentiment
+6. Conclusions
+
+---
+
+```{r setup}
+library(tidyverse)
+library(tidytext)
+library(lsa)
+library(topicmodels)
+library(umap)
+library(ggwordcloud)
+library(textmineR)
+
+knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
+```
+
+---
+
+```{r data-load}
+learn_data <- read_csv("../data/student-math-learning.csv")
+```
+
+---
+
+```{r clean}
+text_df <- learn_data %>%
+  select(text_column = 1) %>%
+  unnest_tokens(word, text_column) %>%
+  anti_join(stop_words, by = "word")
+```
+
+---
+
+```{r lsa}
+term_mat <- text_df %>%
+  count(document = row_number(), word) %>%
+  cast_dtm(document, word, n)
+
+term_tfidf <- weightTfIdf(term_mat)
+lsa_res <- lsa(term_tfidf, dims = 20)
+
+coords <- as.data.frame(lsa_res$dk)
+coords$doc <- rownames(coords)
+
+coords %>%
+  ggplot(aes(Dim1, Dim2)) +
+  geom_point() +
+  theme_minimal()
+```
+
+---
+
+```{r lda}
+lda_model <- LDA(term_mat, k = 8, control = list(seed = 123))
+terms(lda_model, 10) %>%
+  knitr::kable()
+```
+
+---
+
+```{r sentiment}
+text_df %>%
+  inner_join(get_sentiments("nrc"), by = "word") %>%
+  count(sentiment) %>%
+  ggplot(aes(sentiment, n, fill = sentiment)) +
+  geom_col(show.legend = FALSE) +
+  coord_flip() +
+  theme_minimal()
+```
+
+---
+
+# Conclusions
+
+- LSA and LDA highlight topic structure
+- Sentiment shows overall tone
+- Further tuning and validation required
+- **TODO**: integrate additional metadata


### PR DESCRIPTION
## Summary
- scaffold `learning-methods/` project folder
- add install script for required R packages
- create Quarto revealjs slides performing LSA, LDA, and sentiment analysis
- document project setup and usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851da7a9ea483239a70ed8b45d9f3e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a README with project overview, setup instructions, and analysis summary.
  - Introduced an R script to automatically install required packages for text analysis and visualization.
  - Added a Quarto presentation with slides covering data cleaning, LSA, LDA, sentiment analysis, and key findings.

- **Chores**
  - Added a .gitignore to exclude datasets, logs, cache, and user-specific files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->