### PR TITLE
Fix dataset paths and add Kaggle setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore dataset and caches
 /data/
+!data/.gitkeep
+
 *.Rproj.user/
 *.html
 *.pdf

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Aby uruchomić projekt, wykonaj poniższe kroki w terminalu, będąc w głównym
 ```
 learning-methods-lsa-lda/
 ├── data/                          # ⇦ Pliki CSV z Kaggle
-│   └── student-math-learning.csv
+│   └── student_performance_large_dataset.csv
 ├── quarto/
 │   └── learning_lsa_lda.qmd       # ⇦ Główny plik ze slajdami (reveal.js)
 ├── renv/                          # ⇦ Biblioteki R (ignorowane przez .gitignore)
@@ -113,7 +113,7 @@ Aby pobrać dane, potrzebujesz konta na [Kaggle](https://kaggle.com).
 **Co robi skrypt `setup_kaggle.sh`?**
 *   Kopiuje `kaggle.json` do `~/.kaggle/` i ustawia odpowiednie uprawnienia (`chmod 600`).
 *   Pobiera zbiór danych `adilshamim8/student-performance-and-learning-style` do katalogu `data/`.
-*   Rozpakowuje archiwum, tworząc plik `student-math-learning.csv`.
+*   Rozpakowuje archiwum, tworząc plik `student_performance_large_dataset.csv`.
 
 > **Alternatywa (ręczna):** Ustaw zmienne środowiskowe `KAGGLE_USERNAME` i `KAGGLE_KEY`, a następnie wykonaj komendy `kaggle datasets download ...` i `unzip ...` ręcznie.
 
@@ -160,7 +160,7 @@ Plik `quarto/learning_lsa_lda.qmd` zawiera całą logikę analizy danych, podzie
 | Chunk / Sekcja  | Cel i zawartość                                               |
 | :-------------- | :------------------------------------------------------------ |
 | `setup`         | Ładowanie bibliotek R, ustawienia globalne `knitr::opts_chunk$set()`. |
-| `data-load`     | Wczytanie danych z `../data/student-math-learning.csv` do ramki danych `df`. |
+| `data-load`     | Wczytanie danych z `../data/student_performance_large_dataset.csv` do ramki danych `df`. |
 | `clean`         | Czyszczenie tekstu: łączenie kolumn, zmiana na małe litery, tokenizacja, usunięcie stop-words. |
 | `lsa`           | Obliczenie TF-IDF, dopasowanie modelu LSA (`k=20`), wizualizacja 2D (UMAP/PCA). |
 | `lda`           | Modelowanie LDA (`k=8`), ekstrakcja top 10 słów dla każdego tematu. |

--- a/scripts/setup_kaggle.sh
+++ b/scripts/setup_kaggle.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directory for data files
+DATA_DIR="$(dirname "$0")/../data"
+mkdir -p "$DATA_DIR"
+
+# Configure Kaggle credentials if kaggle.json provided in repo root
+if [ ! -f ~/.kaggle/kaggle.json ]; then
+  if [ -f kaggle.json ]; then
+    mkdir -p ~/.kaggle
+    cp kaggle.json ~/.kaggle/
+    chmod 600 ~/.kaggle/kaggle.json
+  else
+    echo "Error: Kaggle API token not found. Place kaggle.json in repo root or ~/.kaggle/" >&2
+    exit 1
+  fi
+fi
+
+# Download dataset
+kaggle datasets download -d adilshamim8/student-performance-and-learning-style -p "$DATA_DIR"
+
+# Unzip and clean up
+ZIP_FILE="$DATA_DIR/student-performance-and-learning-style.zip"
+if [ -f "$ZIP_FILE" ]; then
+  unzip -o "$ZIP_FILE" -d "$DATA_DIR"
+  rm "$ZIP_FILE"
+fi
+
+# Optionally rename main csv to expected name
+MAIN_CSV=$(ls "$DATA_DIR"/*.csv 2>/dev/null | head -n 1)
+if [ -n "$MAIN_CSV" ] && [ ! -f "$DATA_DIR/student_performance_large_dataset.csv" ]; then
+  mv "$MAIN_CSV" "$DATA_DIR/student_performance_large_dataset.csv"
+fi
+
+echo "Data downloaded to $DATA_DIR"


### PR DESCRIPTION
## Summary
- correct dataset filenames in README to match `.qmd`
- allow keeping `data/.gitkeep`
- add script `scripts/setup_kaggle.sh` for easy Kaggle download

## Testing
- `bash -n scripts/setup_kaggle.sh`
- `bash scripts/setup_kaggle.sh` *(fails: Kaggle API token not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857dd7e17b08323ac2a988bf2e80db9