### PR TITLE
Unify dataset naming across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Aby uruchomić projekt, wykonaj poniższe kroki w terminalu, będąc w głównym
 ```
 learning-methods-lsa-lda/
 ├── data/                          # ⇦ Pliki CSV z Kaggle
-│   └── student_performance_large_dataset.csv
+│   └── student_performance.csv
 ├── quarto/
 │   └── learning_lsa_lda.qmd       # ⇦ Główny plik ze slajdami (reveal.js)
 ├── renv/                          # ⇦ Biblioteki R (ignorowane przez .gitignore)
@@ -114,7 +114,7 @@ Aby pobrać dane, potrzebujesz konta na [Kaggle](https://kaggle.com).
 **Co robi skrypt `setup_kaggle.sh`?**
 *   Kopiuje `kaggle.json` do `~/.kaggle/` i ustawia odpowiednie uprawnienia (`chmod 600`).
 *   Pobiera zbiór danych `adilshamim8/student-performance-and-learning-style` do katalogu `data/`.
-*   Rozpakowuje archiwum, tworząc plik `student_performance_large_dataset.csv`.
+*   Rozpakowuje archiwum, tworząc plik `student_performance.csv`.
 
 > **Alternatywa (ręczna):** Ustaw zmienne środowiskowe `KAGGLE_USERNAME` i `KAGGLE_KEY`, a następnie wykonaj komendy `kaggle datasets download ...` i `unzip ...` ręcznie.
 
@@ -162,7 +162,7 @@ Plik `quarto/learning_lsa_lda.qmd` zawiera całą logikę analizy danych, podzie
 | Chunk / Sekcja  | Cel i zawartość                                               |
 | :-------------- | :------------------------------------------------------------ |
 | `setup`         | Ładowanie bibliotek R, ustawienia globalne `knitr::opts_chunk$set()`. |
-| `data-load`     | Wczytanie danych z `../data/student_performance_large_dataset.csv` do ramki danych `df`. |
+| `data-load`     | Wczytanie danych z `data/student_performance.csv` do ramki danych `df`. |
 | `clean`         | Czyszczenie tekstu: łączenie kolumn, zmiana na małe litery, tokenizacja, usunięcie stop-words. |
 | `lsa`           | Obliczenie TF-IDF, dopasowanie modelu LSA (`k=20`), wizualizacja 2D (UMAP/PCA). |
 | `lda`           | Modelowanie LDA (`k=8`), ekstrakcja top 10 słów dla każdego tematu. |

--- a/install.R
+++ b/install.R
@@ -1,19 +1,6 @@
-packages <- c(
-  "tidyverse",
-  "tidytext",
-  "lsa",
-  "topicmodels",
-  "umap",
-  "ggwordcloud",
-  "textmineR",
-  "plotly",
-  "janitor"
-)
+pkgs <- c("tidyverse","janitor","tidytext","topicmodels","textmineR",
+          "tm","SnowballC","wordcloud","knitr","quarto")
 
-install_if_missing <- function(pkg) {
-  if (!requireNamespace(pkg, quietly = TRUE)) {
-    install.packages(pkg, repos = "https://cloud.r-project.org")
-  }
-}
+install_if_missing <- function(p) if (!requireNamespace(p, quietly = TRUE)) install.packages(p)
 
-invisible(lapply(packages, install_if_missing))
+invisible(lapply(pkgs, install_if_missing))

--- a/quarto/learning_lsa_lda.qmd
+++ b/quarto/learning_lsa_lda.qmd
@@ -37,11 +37,11 @@ knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
 ---
 
 ```{r data-load}
-learn_data <- read_csv("../data/student_performance_large_dataset.csv") %>%
+df_raw <- read_csv("data/student_performance.csv") %>%
   janitor::clean_names()
 
 required_cols <- c("learning_style", "performance")
-missing <- setdiff(required_cols, names(learn_data))
+missing <- setdiff(required_cols, names(df_raw))
 if (length(missing) > 0) {
   stop(paste("Missing columns:", paste(missing, collapse = ", ")))
 }
@@ -50,7 +50,7 @@ if (length(missing) > 0) {
 ---
 
 ```{r clean}
-text_df <- learn_data %>%
+text_df <- df_raw %>%
   mutate(document = row_number()) %>%
   select(document, text_column = 1, learning_style, performance) %>%
   unnest_tokens(word, text_column) %>%
@@ -95,7 +95,7 @@ sentiment_doc <- text_df %>%
   group_by(document) %>%
   summarise(sentiment = sum(value, na.rm = TRUE), .groups = "drop")
 
-meta_df <- learn_data %>%
+meta_df <- df_raw %>%
   mutate(document = row_number()) %>%
   select(document, learning_style, performance)
 

--- a/scripts/setup_kaggle.sh
+++ b/scripts/setup_kaggle.sh
@@ -1,36 +1,30 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -e
 
-# Directory for data files
-DATA_DIR="$(dirname "$0")/../data"
-mkdir -p "$DATA_DIR"
+# Download directory
+mkdir -p data
+FILE="data/student_performance.csv"
 
-# Configure Kaggle credentials if kaggle.json provided in repo root
-if [ ! -f ~/.kaggle/kaggle.json ]; then
-  if [ -f kaggle.json ]; then
-    mkdir -p ~/.kaggle
-    cp kaggle.json ~/.kaggle/
-    chmod 600 ~/.kaggle/kaggle.json
-  else
-    echo "Error: Kaggle API token not found. Place kaggle.json in repo root or ~/.kaggle/" >&2
+# Skip if file already present
+if [[ -f "$FILE" ]]; then
+    echo "[INFO] $FILE already exists – skip download."
+    exit 0
+fi
+
+# Verify Kaggle credentials
+if [[ ! -f ~/.kaggle/kaggle.json ]]; then
+    echo "[ERROR] ~/.kaggle/kaggle.json not found. Please configure Kaggle API token." >&2
     exit 1
-  fi
 fi
 
-# Download dataset
-kaggle datasets download -d adilshamim8/student-performance-and-learning-style -p "$DATA_DIR"
+echo "[INFO] Downloading dataset from Kaggle..."
+kaggle datasets download -d adilshamim8/student-performance-and-learning-style -f student_performance.csv -p data/
 
-# Unzip and clean up
-ZIP_FILE="$DATA_DIR/student-performance-and-learning-style.zip"
-if [ -f "$ZIP_FILE" ]; then
-  unzip -o "$ZIP_FILE" -d "$DATA_DIR"
-  rm "$ZIP_FILE"
+# Unzip if necessary
+if ls data/*.zip 1>/dev/null 2>&1; then
+    unzip -o data/*.zip -d data/
+    rm data/*.zip
 fi
 
-# Optionally rename main csv to expected name
-MAIN_CSV=$(ls "$DATA_DIR"/*.csv 2>/dev/null | head -n 1)
-if [ -n "$MAIN_CSV" ] && [ ! -f "$DATA_DIR/student_performance_large_dataset.csv" ]; then
-  mv "$MAIN_CSV" "$DATA_DIR/student_performance_large_dataset.csv"
-fi
-
-echo "Data downloaded to $DATA_DIR"
+mv -f data/*student*performance*.csv "$FILE"
+echo "[INFO] Saved to $FILE"

--- a/scripts/test_data.R
+++ b/scripts/test_data.R
@@ -1,0 +1,2 @@
+stopifnot(all(c("learning_style","performance") %in% 
+              colnames(readr::read_csv("data/student_performance.csv"))))


### PR DESCRIPTION
## Summary
- rename dataset references to `student_performance.csv`
- streamline Kaggle download script
- update package installation list
- load data from new CSV path in Quarto file
- add a simple R test for dataset structure

## Testing
- `Rscript scripts/test_data.R` *(fails: command not found)*
- `quarto render quarto/learning_lsa_lda.qmd --to html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857edfd45148323a607099cf36ee796