### PR TITLE
Fix dataset path and column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Aby uruchomić projekt, wykonaj poniższe kroki w terminalu, będąc w głównym
 ```
 learning-methods-lsa-lda/
 ├── data/                          # ⇦ Pliki CSV z Kaggle
-│   └── student_performance.csv
+│   └── student_performance_large_dataset.csv
 ├── quarto/
 │   └── learning_lsa_lda.qmd       # ⇦ Główny plik ze slajdami (reveal.js)
 ├── renv/                          # ⇦ Biblioteki R (ignorowane przez .gitignore)
@@ -114,7 +114,7 @@ Aby pobrać dane, potrzebujesz konta na [Kaggle](https://kaggle.com).
 **Co robi skrypt `setup_kaggle.sh`?**
 *   Kopiuje `kaggle.json` do `~/.kaggle/` i ustawia odpowiednie uprawnienia (`chmod 600`).
 *   Pobiera zbiór danych `adilshamim8/student-performance-and-learning-style` do katalogu `data/`.
-*   Rozpakowuje archiwum, tworząc plik `student_performance.csv`.
+*   Rozpakowuje archiwum, tworząc plik `student_performance_large_dataset.csv`.
 
 > **Alternatywa (ręczna):** Ustaw zmienne środowiskowe `KAGGLE_USERNAME` i `KAGGLE_KEY`, a następnie wykonaj komendy `kaggle datasets download ...` i `unzip ...` ręcznie.
 
@@ -162,7 +162,7 @@ Plik `quarto/learning_lsa_lda.qmd` zawiera całą logikę analizy danych, podzie
 | Chunk / Sekcja  | Cel i zawartość                                               |
 | :-------------- | :------------------------------------------------------------ |
 | `setup`         | Ładowanie bibliotek R, ustawienia globalne `knitr::opts_chunk$set()`. |
-| `data-load`     | Wczytanie danych z `data/student_performance.csv` do ramki danych `df`. |
+| `data-load`     | Wczytanie danych z `data/student_performance_large_dataset.csv` do ramki danych `df`. |
 | `clean`         | Czyszczenie tekstu: łączenie kolumn, zmiana na małe litery, tokenizacja, usunięcie stop-words. |
 | `lsa`           | Obliczenie TF-IDF, dopasowanie modelu LSA (`k=20`), wizualizacja 2D (UMAP/PCA). |
 | `lda`           | Modelowanie LDA (`k=8`), ekstrakcja top 10 słów dla każdego tematu. |

--- a/quarto/learning_lsa_lda.qmd
+++ b/quarto/learning_lsa_lda.qmd
@@ -37,10 +37,10 @@ knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
 ---
 
 ```{r data-load}
-df_raw <- read_csv("data/student_performance.csv") %>%
+df_raw <- read_csv("data/student_performance_large_dataset.csv") %>%
   janitor::clean_names()
 
-required_cols <- c("learning_style", "performance")
+required_cols <- c("gender", "math_score")
 missing <- setdiff(required_cols, names(df_raw))
 if (length(missing) > 0) {
   stop(paste("Missing columns:", paste(missing, collapse = ", ")))
@@ -52,7 +52,7 @@ if (length(missing) > 0) {
 ```{r clean}
 text_df <- df_raw %>%
   mutate(document = row_number()) %>%
-  select(document, text_column = 1, learning_style, performance) %>%
+  select(document, text_column = study_notes, gender, math_score) %>%
   unnest_tokens(word, text_column) %>%
   anti_join(stop_words, by = "word")
 ```
@@ -97,7 +97,7 @@ sentiment_doc <- text_df %>%
 
 meta_df <- df_raw %>%
   mutate(document = row_number()) %>%
-  select(document, learning_style, performance)
+  select(document, gender, math_score)
 
 topic_meta <- topic_df %>%
   left_join(meta_df, by = "document") %>%
@@ -122,11 +122,11 @@ text_df %>%
 
 ```{r style-comparison}
 style_summary <- topic_meta %>%
-  group_by(learning_style) %>%
+  group_by(gender) %>%
   summarise(avg_sentiment = mean(sentiment, na.rm = TRUE))
 
 p_style <- ggplot(style_summary,
-                  aes(learning_style, avg_sentiment, fill = learning_style)) +
+                  aes(gender, avg_sentiment, fill = gender)) +
   geom_col(show.legend = FALSE) +
   theme_minimal()
 
@@ -145,7 +145,7 @@ umap_df$document <- as.integer(coords$doc)
 umap_df <- left_join(umap_df, topic_meta, by = "document")
 
 p_umap <- ggplot(umap_df,
-                 aes(Dim1, Dim2, color = learning_style,
+                 aes(Dim1, Dim2, color = gender,
                      text = paste0("Doc ", document,
                                     "<br>Topic ", dominant_topic))) +
   geom_point() +
@@ -164,7 +164,7 @@ topic_stats <- topic_meta %>%
   summarise(
     responses = n(),
     avg_sentiment = mean(sentiment, na.rm = TRUE),
-    avg_perf = mean(performance, na.rm = TRUE)
+    avg_perf = mean(math_score, na.rm = TRUE)
   )
 
 knitr::kable(topic_stats)

--- a/scripts/setup_kaggle.sh
+++ b/scripts/setup_kaggle.sh
@@ -3,7 +3,7 @@ set -e
 
 # Download directory
 mkdir -p data
-FILE="data/student_performance.csv"
+FILE="data/student_performance_large_dataset.csv"
 
 # Skip if file already present
 if [[ -f "$FILE" ]]; then
@@ -18,7 +18,7 @@ if [[ ! -f ~/.kaggle/kaggle.json ]]; then
 fi
 
 echo "[INFO] Downloading dataset from Kaggle..."
-kaggle datasets download -d adilshamim8/student-performance-and-learning-style -f student_performance.csv -p data/
+kaggle datasets download -d adilshamim8/student-performance-and-learning-style -f student_performance_large_dataset.csv -p data/
 
 # Unzip if necessary
 if ls data/*.zip 1>/dev/null 2>&1; then

--- a/scripts/test_data.R
+++ b/scripts/test_data.R
@@ -1,2 +1,2 @@
-stopifnot(all(c("learning_style","performance") %in% 
-              colnames(readr::read_csv("data/student_performance.csv"))))
+stopifnot(all(c("gender","math_score") %in% 
+              colnames(readr::read_csv("data/student_performance_large_dataset.csv"))))


### PR DESCRIPTION
## Summary
- update dataset references across repo
- adapt Quarto analysis to `gender` and `math_score`
- tweak Kaggle setup and test script for new CSV

## Testing
- `quarto check`
- `quarto render quarto/learning_lsa_lda.qmd --no-execute` *(fails: there is no package called 'rmarkdown')*

------
https://chatgpt.com/codex/tasks/task_e_6857f7a824bc8323a74b1d7811f1058e