### PR TITLE
Simplify sentiment workflow and add CI

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -1,0 +1,13 @@
+name: Render
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install deps
+        run: Rscript install.R
+      - name: Render
+        run: quarto render quarto/learning_lsa_lda.qmd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+- Add GitHub Actions workflow to render Quarto slides.
+- Ensure AFINN lexicon downloads automatically.
+- Enable code folding and caching in Quarto document.
+- Simplify sentiment calculation using `.by` syntax.
+- Provide basic test to verify rendered HTML.

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,8 @@
+# Helper functions for text analysis
+
+calc_sentiment <- function(opinions) {
+  opinions |>
+    tidytext::unnest_tokens(word, text) |>
+    inner_join(get_sentiments("afinn"), by = "word") |>
+    dplyr::summarise(sentiment = sum(value), .by = id)
+}

--- a/install.R
+++ b/install.R
@@ -8,6 +8,12 @@ install_if_missing <- function(p) if (!requireNamespace(p, quietly = TRUE)) inst
 
 invisible(lapply(pkgs, install_if_missing))
 
+# Ensure AFINN lexicon is available for offline use
+if (!textdata::lexicon_afinn_exists()) {
+  textdata::lexicon_afinn(download = "force")
+}
+options(textdata.download = TRUE)
+
 # Pre-download lexicons to avoid interactive prompts during rendering
 print("[INFO] Downloading sentiment lexicons...")
 tryCatch({

--- a/quarto-project.yml
+++ b/quarto-project.yml
@@ -1,0 +1,8 @@
+project:
+  type: default
+
+execute:
+  freeze: auto
+
+resources:
+  - R/utils.R

--- a/quarto/learning_lsa_lda.qmd
+++ b/quarto/learning_lsa_lda.qmd
@@ -1,6 +1,11 @@
 ---
 title: "Learning Methods Analysis"
-format: revealjs
+format:
+  revealjs:
+    code-fold: true
+  html:
+    code-fold: true
+freeze: auto
 ---
 
 # Title
@@ -105,10 +110,9 @@ topic_df <- as.data.frame(doc_topics)
 topic_df$document <- as.integer(rownames(topic_df))
 topic_df$dominant_topic <- apply(doc_topics, 1, which.max)
 
-sentiment_doc <- text_df %>%
-  inner_join(get_sentiments("afinn"), by = "word") %>%
-  group_by(document) %>%
-  summarise(sentiment = sum(value, na.rm = TRUE), .groups = "drop")
+sentiment_doc <- text_df |>
+  inner_join(get_sentiments("afinn"), by = "word") |>
+  summarise(sentiment = sum(value, na.rm = TRUE), .by = document)
 
 meta_df <- df_raw %>%
   mutate(document = row_number()) %>%

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,1 @@
+testthat::test_dir("tests/testthat")

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,0 +1,3 @@
+test_that("html output exists", {
+  expect_true(file.exists("quarto/learning_lsa_lda.html"))
+})


### PR DESCRIPTION
## Summary
- pre-download AFINN lexicon in `install.R`
- enable code folding and caching in the Quarto slides
- simplify sentiment calculation using `.by` syntax
- add helper utilities, CI workflow, and basic test

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685863975cc88323828362180762f863