### PR TITLE
Fix stop_words variable in Quarto setup

### DIFF
--- a/quarto/learning_lsa_lda.qmd
+++ b/quarto/learning_lsa_lda.qmd
@@ -28,6 +28,7 @@ freeze: auto
 ```{r setup}
 library(tidyverse)
 library(tidytext)
+stop_words <- tidytext::stop_words
 library(lsa)
 library(topicmodels)
 library(umap)


### PR DESCRIPTION
## Summary
- define `stop_words` in the setup chunk of the Quarto document

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586dafb7108323bb85465bd6075ce6