### PR TITLE
Update render workflow

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -7,7 +7,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2
+      - uses: quarto-dev/quarto-actions/setup@v2
       - name: Install deps
         run: Rscript install.R
+      - name: Setup Kaggle
+        run: bash scripts/setup_kaggle.sh
       - name: Render
         run: quarto render quarto/learning_lsa_lda.qmd
+      - name: Run tests
+        run: Rscript -e 'testthat::test_dir("tests/testthat")'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.1.0 (2025-06-22)
+
+
+### Features
+
+* unify dataset naming and update scripts 6765fc0
+
+# Changelog
+
 ## [Unreleased]
 - Add GitHub Actions workflow to render Quarto slides.
 - Ensure AFINN lexicon downloads automatically.


### PR DESCRIPTION
## Summary
- install Quarto using `quarto-dev/quarto-actions/setup@v2`
- call `bash scripts/setup_kaggle.sh` to fetch Kaggle data
- run tests at the end of the workflow

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586db1ffdc8323a0da560b70a8e744