### PR TITLE
Simplify sentiment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,8 @@ install_if_missing <- function(p) {
 
 invisible(lapply(pkgs, install_if_missing))
 
-library(textdata)
-textdata::download_lexicon("afinn")
-textdata::download_lexicon("nrc")
+# Pobranie słownika AFINN (używany w przykładzie sentymentu)
+tidytext::get_sentiments("afinn")
 ```
 
 ---
@@ -157,7 +156,7 @@ Plik `quarto/learning_lsa_lda.qmd` zawiera całą logikę analizy danych, podzie
 | `clean`         | Tworzenie kolumny tekstowej do analizy (z braku danych opisowych), czyszczenie tekstu: zmiana na małe litery, tokenizacja, usunięcie stop-words. |
 | `lsa`           | Obliczenie TF-IDF, dopasowanie modelu LSA (`k=20`), wizualizacja 2D (UMAP/PCA). |
 | `lda`           | Modelowanie LDA (`k=8`), ekstrakcja top 10 słów dla każdego tematu. |
-| `sentiment`     | Analiza sentymentu z użyciem słownika NRC, wizualizacja emocji (barplot, chmura słów). |
+| `sentiment`     | Analiza sentymentu z użyciem słownika AFINN, prosta wizualizacja wyniku. |
 | `gpa-boxplot`   | Wizualizacja zależności GPA od stylu nauki (boxplot).         |
 | `conclusions`   | Podsumowanie (3-5 głównych wniosków) i omówienie ograniczeń modelu. |
 
@@ -175,7 +174,7 @@ quarto render quarto/learning_lsa_lda.qmd --to revealjs
 | **TF-IDF**  | Miara ważności słowa: rośnie, gdy słowo jest rzadkie w całym zbiorze tekstów. | Służy jako macierz wejściowa dla modelu LSA.                  |
 | **LSA**     | Metoda matematyczna redukująca tysiące słów do kilkunastu "ukrytych wymiarów znaczeń". | Umożliwia wizualizację studentów w 2D i pokolorowanie ich według metody nauki. |
 | **LDA**     | Algorytm, który "odgaduje" tematy, na jakie można podzielić zbiór tekstów. | Zidentyfikowano 8 głównych tematów wraz z listą najważniejszych słów. |
-| **NRC Lexicon** | Gotowy słownik mapujący słowa na 8 podstawowych emocji i polaryzację (pozytywna/negatywna). | Obliczono, które emocje dominują w opisach stylów nauki.     |
+| **AFINN Lexicon** | Prosty słownik ocenianych słów od -5 do 5. | Używany do obliczenia podstawowego wyniku sentymentu. |
 | **UMAP**    | Algorytm redukcji wymiaru, który dobrze zachowuje lokalne sąsiedztwa punktów. | Użyty jako alternatywa dla PCA do tworzenia czytelniejszych wykresów 2D. |
 
 ---

--- a/quarto/learning_lsa_lda.qmd
+++ b/quarto/learning_lsa_lda.qmd
@@ -132,7 +132,8 @@ topic_meta <- topic_df %>%
 
 ```{r sentiment}
 text_df %>%
-  inner_join(get_sentiments("nrc"), by = "word") %>%
+  inner_join(get_sentiments("afinn"), by = "word") %>%
+  mutate(sentiment = ifelse(value > 0, "positive", "negative")) %>%
   count(sentiment) %>%
   ggplot(aes(sentiment, n, fill = sentiment)) +
   geom_col(show.legend = FALSE) +


### PR DESCRIPTION
## Summary
- trim down `install.R` so it no longer downloads the NRC lexicon
- update README instructions for new AFINN-based sentiment step
- use AFINN lexicon in slides

## Testing
- `Rscript install.R` *(fails: command not found)*
- `Rscript -e 'source("tests/testthat.R")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859724547b08323a1c24f20f26e67a5