### PR TITLE
Fix Quarto preview by installing dbscan

### DIFF
--- a/install.R
+++ b/install.R
@@ -9,7 +9,7 @@ pkgs <- c(
   "tidyverse", "janitor", "tidytext",
   "topicmodels", "textmineR", "tm", "SnowballC",
   "wordcloud", "knitr", "quarto",
-  "lsa", "umap", "plotly", "ggwordcloud"
+  "lsa", "umap", "plotly", "ggwordcloud", "dbscan"
 )
 
 # 3. Helper to install packages with retries


### PR DESCRIPTION
## Summary
- add `dbscan` to the dependency list in `install.R`

## Testing
- `Rscript -e 'source("tests/testthat.R")'` *(fails: there is no package called `testthat`)*
- `quarto render quarto/learning_lsa_lda.qmd --to html` *(fails: there is no package called `rmarkdown`)*

------
https://chatgpt.com/codex/tasks/task_e_6864111c94208323a1028bfa16ad354b