### PR TITLE
Fix UMAP slide failing due to missing topic_meta

### DIFF
--- a/quarto/learning_lsa_lda.qmd
+++ b/quarto/learning_lsa_lda.qmd
@@ -143,32 +143,6 @@ coords %>%
   theme_minimal()
 ```
 
----
-
-## Klastry tematów (UMAP)
-
-```{r umap}
-n_items <- nrow(lsa_res$dk)
-if (n_items < 3) {
-  stop("Need at least 3 documents for UMAP")
-}
-n_neighbors <- min(15, n_items - 1)
-umap_res <- umap(lsa_res$dk, n_neighbors = n_neighbors)
-umap_df <- as.data.frame(umap_res$layout)
-colnames(umap_df) <- c("Dim1", "Dim2")
-umap_df$document <- as.integer(coords$doc)
-umap_df <- left_join(umap_df, topic_meta, by = "document")
-
-p_umap <- ggplot(umap_df,
-                 aes(Dim1, Dim2, color = learning_style,
-                     text = paste0("Doc ", document,
-                                    "<br>Topic ", dominant_topic))) +
-  geom_point() +
-  theme_minimal()
-
-ggplotly(p_umap)
-```
----
 
 ```{r lda}
 lda_model <- LDA(term_mat, k = 4, control = list(seed = 123))
@@ -195,6 +169,32 @@ meta_df <- df_raw %>%
 topic_meta <- topic_df %>%
   left_join(meta_df, by = "document") %>%
   left_join(sentiment_doc, by = "document")
+```
+
+---
+
+## Klastry tematów (UMAP)
+
+```{r umap}
+n_items <- nrow(lsa_res$dk)
+if (n_items < 3) {
+  stop("Need at least 3 documents for UMAP")
+}
+n_neighbors <- min(15, n_items - 1)
+umap_res <- umap(lsa_res$dk, n_neighbors = n_neighbors)
+umap_df <- as.data.frame(umap_res$layout)
+colnames(umap_df) <- c("Dim1", "Dim2")
+umap_df$document <- as.integer(coords$doc)
+umap_df <- left_join(umap_df, topic_meta, by = "document")
+
+p_umap <- ggplot(umap_df,
+                 aes(Dim1, Dim2, color = learning_style,
+                     text = paste0("Doc ", document,
+                                    "<br>Topic ", dominant_topic))) +
+  geom_point() +
+  theme_minimal()
+
+ggplotly(p_umap)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- compute the LDA model and topic metadata before running the UMAP slide
- move the UMAP code below the LDA preparation chunk

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865aa7310f48323852a85651a3f0370