### PR TITLE
Add heading check to render test

### DIFF
--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,3 +1,12 @@
-test_that("html output exists", {
-  expect_true(file.exists("quarto/learning_lsa_lda.html"))
+test_that("rendered HTML contains expected heading", {
+  skip_if(Sys.which("quarto") == "", "quarto command not found")
+
+  html_file <- file.path("quarto", "learning_lsa_lda.html")
+  if (!file.exists(html_file) || file.info(html_file)$size == 0) {
+    quarto::quarto_render(file.path("quarto", "learning_lsa_lda.qmd"))
+  }
+
+  expect_true(file.exists(html_file))
+  lines <- readLines(html_file, warn = FALSE)
+  expect_true(any(grepl("Plan prezentacji", lines)))
 })


### PR DESCRIPTION
## Summary
- ensure generated HTML contains a heading
- skip test if `quarto` CLI is missing

## Testing
- `Rscript tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_68665c7a0c2c8323af6ddc106207b3b0